### PR TITLE
Raise checkout and clang-format-action version. Add execute conditions

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,5 +1,27 @@
 name: clang-format Check
-on: [push, pull_request]
+
+env:
+  INCLUDE_REGEX: ^.*\.((((c|C)(c|pp|xx|\+\+)?$)|((h|H)h?(pp|xx|\+\+)?$))|(inl|ino|pde|proto|cu))$
+
+on:
+  push:
+    paths:
+      - '**.ino'
+      - '**.cpp'
+      - '**.hpp'
+      - '**.h'
+      - '**.c'
+      - '**.inl'
+      - '**clang-format-check.yml'
+    pull_request:
+      - '**.ino'
+      - '**.cpp'
+      - '**.hpp'
+      - '**.h'
+      - '**.c'
+      - '**.inl'
+      - '**clang-format-check.yml'
+
 jobs:
   formatting-check:
     name: Formatting Check
@@ -9,15 +31,21 @@ jobs:
         path:
           - check: './'    # path to include
             exclude: ''    # path to exclude
-          # - check: 'src'
-          #   exclude: '(Fonts)' # Exclude file paths containing "Fonts"
-          # - check: 'examples'
-          #   exclude: ''
+          #- check: 'src'
+          #  exclude: '(Fonts)' # Exclude file paths containing "Fonts"
+          #- check: 'examples'
+          #  exclude: ''
+
     steps:
-    - uses: actions/checkout@v3.1.0
-    - name: Run clang-format style check for C/C++/Protobuf programs.
-      uses: jidicula/clang-format-action@v4.9.0
-      with:
-        clang-format-version: '13'
-        check-path: ${{ matrix.path['check'] }}
-        exclude-regex: ${{ matrix.path['exclude'] }}
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Run clang-format style check for C/C++/Protobuf programs.
+        uses: jidicula/clang-format-action@v4.10.2 # Using include-regex 10.x or later
+        with:
+          clang-format-version: '13'
+          check-path: ${{ matrix.path['check'] }}
+          exclude-regex: ${{ matrix.path['exclude'] }}
+          include-regex: ${{ env.INCLUDE_REGEX }}


### PR DESCRIPTION
- Added the condition that the file must be a file with the target extension, since it works unconditionally regardless of the file type.  
  For example, it also works when a .txt file is modified.
This will result in unnecessary Actions being run.
- Raise checkout version from v3 to v4. 
  Use node20 editions
- Raise clang-format-action from v4.9 0 to v4.10.2. 
 Need to upgrade to use the option to increase target file extensions

M5UnitUnified related uses this as a basis.

Please consider it.